### PR TITLE
fix: correct documentation build paths and tag formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
     tags:
       - 'bsharp_parser-*'
+      - 'bsharp-parser-*'
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -62,7 +63,8 @@ jobs:
     needs: build
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') ||
-      startsWith(github.ref, 'refs/tags/bsharp_parser-')
+      startsWith(github.ref, 'refs/tags/bsharp_parser-') ||
+      startsWith(github.ref, 'refs/tags/bsharp-parser-')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install admonish assets
         run: mdbook-admonish install .
-        working-directory: .
+        working-directory: docs
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -73,8 +73,8 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build docs (mdBook) into Astro public/docs
-        run: mdbook build -d site/public/docs
-        working-directory: .
+        run: mdbook build -d ../site/public/docs
+        working-directory: docs
 
       - name: Build Astro (Bun)
         run: bun run build


### PR DESCRIPTION
- Updated tag format to support both "bsharp_parser-*" and "bsharp-parser-*" variants
- Fixed working directory paths in mdbook.yml to properly reference docs folder
- Modified mdbook build output path to correctly target site/public/docs from docs directory
- Added missing tag format to publish job condition in CI workflow

The changes ensure documentation builds correctly and package releases work with both hyphenated and underscore tag formats.